### PR TITLE
Mover la configuración <bindings> del app.config a código

### DIFF
--- a/OpenInvoicePeru/OpenInvoicePeru.Servicio.Soap/OpenInvoicePeru.Servicio.Soap.csproj
+++ b/OpenInvoicePeru/OpenInvoicePeru.Servicio.Soap/OpenInvoicePeru.Servicio.Soap.csproj
@@ -30,10 +30,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Web.Services3, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Web.Services3.3.0.0.0\lib\net20\Microsoft.Web.Services3.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Serialization" />
@@ -75,7 +71,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
-    <None Include="packages.config" />
     <None Include="Service References\Consultas\billConsultService.wsdl" />
     <None Include="Service References\Consultas\billConsultService.xsd">
       <SubType>Designer</SubType>

--- a/OpenInvoicePeru/OpenInvoicePeru.Servicio.Soap/PasswordDigestMessageInspector.cs
+++ b/OpenInvoicePeru/OpenInvoicePeru.Servicio.Soap/PasswordDigestMessageInspector.cs
@@ -2,7 +2,6 @@
 using System.ServiceModel.Channels;
 using System.ServiceModel.Dispatcher;
 using System.Xml;
-using Microsoft.Web.Services3.Security.Tokens;
 using OpenInvoicePeru.Comun.Constantes;
 
 namespace OpenInvoicePeru.Servicio.Soap
@@ -27,18 +26,18 @@ namespace OpenInvoicePeru.Servicio.Soap
 
         public object BeforeSendRequest(ref Message request, System.ServiceModel.IClientChannel channel)
         {
-            var token = new UsernameToken(Username, Password, PasswordOption.SendPlainText);
+            //var token = new UsernameToken(Username, Password, PasswordOption.SendPlainText);
 
-            var securityToken = token.GetXml(new XmlDocument());
+            //var securityToken = token.GetXml(new XmlDocument());
 
-            // Modificamos el XML Generado.
-            var nodo = securityToken.GetElementsByTagName("wsse:Nonce").Item(0);
-            nodo?.RemoveAll();
+            //// Modificamos el XML Generado.
+            //var nodo = securityToken.GetElementsByTagName("wsse:Nonce").Item(0);
+            //nodo?.RemoveAll();
 
-            var securityHeader = MessageHeader.CreateHeader("Security",
-                EspacioNombres.wssecurity,
-                securityToken, false);
-            request.Headers.Add(securityHeader);
+            //var securityHeader = MessageHeader.CreateHeader("Security",
+            //    EspacioNombres.wssecurity,
+            //    securityToken, false);
+            //request.Headers.Add(securityHeader);
 
             return Convert.DBNull;
         }

--- a/OpenInvoicePeru/OpenInvoicePeru.Servicio.Soap/app.config
+++ b/OpenInvoicePeru/OpenInvoicePeru.Servicio.Soap/app.config
@@ -1,24 +1,3 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
-  <system.serviceModel>
-    <bindings>
-      <basicHttpBinding>
-        <binding name="SunatDocumentosBinding">
-          <security mode="Transport" />
-        </binding>
-      </basicHttpBinding>
-    </bindings>
-    <client>
-      <endpoint address="https://e-beta.sunat.gob.pe/ol-ti-itcpfegem-beta/billService"
-                binding="basicHttpBinding"
-                bindingConfiguration="SunatDocumentosBinding"
-                contract="Documentos.billService"
-                name="ServicioSunat" />
-      <endpoint address="https://www.sunat.gob.pe/ol-it-wsconscpegem/billConsultService"
-                binding="basicHttpBinding"
-                bindingConfiguration="SunatDocumentosBinding"
-                contract="Consultas.billService"
-                name="ConsultasSunat" />
-    </client>
-  </system.serviceModel>
 </configuration>

--- a/OpenInvoicePeru/OpenInvoicePeru.Servicio.Soap/packages.config
+++ b/OpenInvoicePeru/OpenInvoicePeru.Servicio.Soap/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Microsoft.Web.Services3" version="3.0.0.0" targetFramework="net461" />
-</packages>


### PR DESCRIPTION
- No depender de la configuración en el app.config de la aplicación que use el ensamblado.
- No tener dependencia de Microsoft.Web.Services3.

Verificación del envió de los headers de seguridad:
![openinvoice](https://user-images.githubusercontent.com/14926587/31026245-57332aca-a50b-11e7-92e4-ac68c95b34b6.PNG)