### PR TITLE
Nodo de AdditionalDocumentReference

### DIFF
--- a/OpenInvoicePeru/OpenInvoicePeru.Comun.Dto/Modelos/DocumentoElectronico.cs
+++ b/OpenInvoicePeru/OpenInvoicePeru.Comun.Dto/Modelos/DocumentoElectronico.cs
@@ -77,6 +77,9 @@ namespace OpenInvoicePeru.Comun.Dto.Modelos
         public List<DocumentoRelacionado> Relacionados { get; set; }
 
         [JsonProperty(Required = Required.AllowNull)]
+        public List<DocumentoRelacionado> OtrosDocumentosRelacionados { get; set; }
+
+        [JsonProperty(Required = Required.AllowNull)]
         public List<Discrepancia> Discrepancias { get; set; }
 
         [JsonProperty(Required = Required.Always)]
@@ -102,6 +105,7 @@ namespace OpenInvoicePeru.Comun.Dto.Modelos
             Items = new List<DetalleDocumento>();
             DatoAdicionales = new List<DatoAdicional>();
             Relacionados = new List<DocumentoRelacionado>();
+            OtrosDocumentosRelacionados = new List<DocumentoRelacionado>();
             Discrepancias = new List<Discrepancia>();
             TipoDocumento = "01"; // Factura.
             TipoOperacion = "01"; // Venta Interna.

--- a/OpenInvoicePeru/OpenInvoicePeru.Estructuras/EstandarUbl/Invoice.cs
+++ b/OpenInvoicePeru/OpenInvoicePeru.Estructuras/EstandarUbl/Invoice.cs
@@ -32,6 +32,8 @@ namespace OpenInvoicePeru.Estructuras.EstandarUbl
 
         public List<InvoiceDocumentReference> DespatchDocumentReferences { get; set; }
 
+        public List<InvoiceDocumentReference> AdditionalDocumentReferences { get; set; }
+
         public string DocumentCurrencyCode { get; set; }
 
         public List<TaxTotal> TaxTotals { get; set; }
@@ -51,6 +53,7 @@ namespace OpenInvoicePeru.Estructuras.EstandarUbl
             AccountingSupplierParty = new AccountingSupplierParty();
             AccountingCustomerParty = new AccountingSupplierParty();
             DespatchDocumentReferences = new List<InvoiceDocumentReference>();
+            AdditionalDocumentReferences = new List<InvoiceDocumentReference>();
             UblExtensions = new UblExtensions();
             Signature = new SignatureCac();
             InvoiceLines = new List<InvoiceLine>();
@@ -407,6 +410,20 @@ namespace OpenInvoicePeru.Estructuras.EstandarUbl
             }
 
             #endregion DespatchDocumentReferences
+
+            #region AdditionalDocumentReferences
+
+            foreach (var reference in AdditionalDocumentReferences)
+            {
+                writer.WriteStartElement("cac:AdditionalDocumentReference");
+                {
+                    writer.WriteElementString("cbc:ID", reference.Id);
+                    writer.WriteElementString("cbc:DocumentTypeCode", reference.DocumentTypeCode);
+                }
+                writer.WriteEndElement();
+            }
+
+            #endregion AdditionalDocumentReferences
 
             #region Signature
 

--- a/OpenInvoicePeru/OpenInvoicePeru.Xml/FacturaXml.cs
+++ b/OpenInvoicePeru/OpenInvoicePeru.Xml/FacturaXml.cs
@@ -286,6 +286,15 @@ namespace OpenInvoicePeru.Xml
                 });
             }
 
+            foreach (var relacionado in documento.OtrosDocumentosRelacionados)
+            {
+                invoice.AdditionalDocumentReferences.Add(new InvoiceDocumentReference
+                {
+                    DocumentTypeCode = relacionado.TipoDocumento,
+                    Id = relacionado.NroDocumento
+                });
+            }
+
             if (documento.Gratuitas > 0)
             {
                 invoice.UblExtensions.Extension2.ExtensionContent

--- a/OpenInvoicePeru/OpenInvoicePeru.Xml/NotaCreditoXml.cs
+++ b/OpenInvoicePeru/OpenInvoicePeru.Xml/NotaCreditoXml.cs
@@ -198,6 +198,15 @@ namespace OpenInvoicePeru.Xml
                 });
             }
 
+            foreach (var relacionado in documento.OtrosDocumentosRelacionados)
+            {
+                creditNote.AdditionalDocumentReferences.Add(new InvoiceDocumentReference
+                {
+                    DocumentTypeCode = relacionado.TipoDocumento,
+                    Id = relacionado.NroDocumento
+                });
+            }
+
             foreach (var detalleDocumento in documento.Items)
             {
                 var linea = new InvoiceLine

--- a/OpenInvoicePeru/OpenInvoicePeru.Xml/NotaDebitoXml.cs
+++ b/OpenInvoicePeru/OpenInvoicePeru.Xml/NotaDebitoXml.cs
@@ -198,6 +198,15 @@ namespace OpenInvoicePeru.Xml
                 });
             }
 
+            foreach (var relacionado in documento.OtrosDocumentosRelacionados)
+            {
+                debitNote.AdditionalDocumentReferences.Add(new InvoiceDocumentReference
+                {
+                    DocumentTypeCode = relacionado.TipoDocumento,
+                    Id = relacionado.NroDocumento
+                });
+            }
+
             foreach (var detalleDocumento in documento.Items)
             {
                 var linea = new InvoiceLine


### PR DESCRIPTION
### Tipo y número de otro documento y/ código documento relacionado con la operación que se factura.

Referencia a cualquier otro documento, asociado a la factura. Podrán especificarse documentos como comprobantes de retención, percepción, código SCOP, etc. Pueden existir documentos de distintos tipos asociados a una misma factura, por lo que el número de elementos de este tipo es ilimitado. Se utilizará el Catálogo No. 12: “Códigos - Documentos Relacionados Tributarios”.

**Ubicación**
//Invoice/cac:AdditionalDocumentReference/cbc:ID
//Invoice/cac:AdditionalDocumentReference/cbc:DocumentTypeCode

**Ejemplo**
```xml
<cac:AdditionalDocumentReference>
  <cbc:ID>G008-024099</cbc:ID>
  <cbc:DocumentTypeCode>12</cbc:DocumentTypeCode>
</cac:AdditionalDocumentReference>
```
