### PR TITLE
Obtener el N° ticket de CDR en el metodo EnviarDocumento

### DIFF
--- a/OpenInvoicePeru/OpenInvoicePeru.Comun.Dto/Intercambio/EnviarDocumentoResponse.cs
+++ b/OpenInvoicePeru/OpenInvoicePeru.Comun.Dto/Intercambio/EnviarDocumentoResponse.cs
@@ -7,5 +7,7 @@
         public string MensajeRespuesta { get; set; }
 
         public string TramaZipCdr { get; set; }
+
+        public string NroTicketCdr { get; set; }
     }
 }

--- a/OpenInvoicePeru/OpenInvoicePeru.Firmado/Serializador.cs
+++ b/OpenInvoicePeru/OpenInvoicePeru.Firmado/Serializador.cs
@@ -105,9 +105,15 @@ namespace OpenInvoicePeru.Firmado
                                     xmlDoc.SelectSingleNode(EspacioNombres.nodoResponseCode,
                                         xmlnsManager)?.InnerText;
 
+
                                 response.MensajeRespuesta =
                                     xmlDoc.SelectSingleNode(EspacioNombres.nodoDescription,
                                         xmlnsManager)?.InnerText;
+
+                                response.NroTicketCdr =
+                                    xmlDoc.SelectSingleNode(EspacioNombres.nodoId,
+                                        xmlnsManager)?.InnerText;
+
                                 response.TramaZipCdr = constanciaRecepcion;
                                 response.NombreArchivo = entry.FileName;
                                 response.Exito = true;


### PR DESCRIPTION
Se agrega la propiedad NroTicketCdr en la clase EnviarDocumentoResponse, para obtener el número de ticket de  CDR para obtener en cualquier momento, con el metodo ConsultarTicket, Ya que la SUNAT indico que se debe obtener el CDR cuando los documento se envio correctamente pero no retorno el CDR de forma oportuna. esto podria ser una opcion al metodo ConsultarConstancia ya que no devuelve un CDR.